### PR TITLE
Add switches for mouse and keyboard movement

### DIFF
--- a/Invoke-Rick.ps1
+++ b/Invoke-Rick.ps1
@@ -10,10 +10,13 @@
     Author: @MJVL (https://github.com/MJVL)
 .EXAMPLE
     PS> iex ((New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/MJVL/Invoke-Rick/blob/main/Invoke-Rick.ps1"))
-        Download and run this script remotely. 
+        Download and run this script remotely.
+.EXAMPLE 
+    PS> .\Invoke-Rick.ps1 -WatchMouse -WatchKeyboard
+        Rickroll, restoring the original background temporarily if keyboard or mouse activity is detected.
 .EXAMPLE 
     PS> .\Invoke-Rick.ps1 -FakeoutDuration (New-TimeSpan -Minutes 2) -EndTime ((Get-Date).AddMinutes(5))
-        Rickroll for 5 minutes, showing the user's original desktop every 2 minutes.
+        Rickroll for 5 minutes, showing the user's original background every 2 minutes.
 .EXAMPLE
     PS> .\Invoke-Rick.ps1 -Verbose
         Show debug information.
@@ -36,15 +39,20 @@ param(
     [Parameter(HelpMessage = "Delay between each frame. Default = 1 second.")] # Delay between each frame. Default = 1 second.
     [timespan]$FrameDelay = (New-TimeSpan -Seconds 1),
     [ValidateNotNullOrEmpty()]
-    [Parameter(HelpMessage = "How long to rickroll until returning to the user's normal background. Default = 5 minutes.")] # How long to rickroll until returning to the user's normal background. Default = 1 minute.
+    [Parameter(HelpMessage = "How long to rickroll until returning to the normal background. Default = 5 minutes.")] # How long to rickroll until returning to the normal background. Default = 1 minute.
     [timespan]$FakeoutDelay = (New-TimeSpan -Minutes 5),
-    [Parameter(HelpMessage = "How long to remain on the user's normal background during a fakeout. Default = 5 minutes.")] # How long to remain on the user's normal background during a fakeout. Default = 5 minutes.
+    [Parameter(HelpMessage = "How long to remain on the normal background during a fakeout. Default = 5 minutes.")] # How long to remain on the normal background during a fakeout. Default = 5 minutes.
+    [ValidateNotNullOrEmpty()]
     [timespan]$FakeoutDuration = (New-TimeSpan -Minutes 5),
     [Parameter(HelpMessage = "Absolute time to kill Invoke-Rick at. Default = run forever.")] # Absolute time to kill Invoke-Rick at. Default = run forever.
+    [ValidateNotNullOrEmpty()]
     [datetime]$EndTime,
-    [Parameter(HelpMessage = "Restore user's normal background if mouse movement is detected. Polling rate is linked with -FrameDelay.")] # Restore user's normal background if mouse movement is detected. Polling rate is linked with -FrameDelay.
+    [Parameter(HelpMessage = "Restore normal background if mouse movement is detected. Polling rate is linked with -FrameDelay.")] # Restore normal background if mouse movement is detected. Polling rate is linked with -FrameDelay.
     [switch]$WatchMouse,
-    [Parameter(HelpMessage = "How long to remain on the user's normal background after detecting movement from the mouse or keyboard. Default = 1 minute.")] # How long to remain on the user's normal background after detecting movement from the mouse or keyboard. Default = 1 minute
+    [Parameter(HelpMessage = "Restore normal background if keypresses are detected. Polling rate is linked with -FrameDelay.")] # Restore normal background if keypresses is detected. Polling rate is linked with -FrameDelay.
+    [switch]$WatchKeyboard,
+    [Parameter(HelpMessage = "How long to remain on the normal background after detecting movement from the mouse or keyboard. Default = 1 minute.")] # How long to remain on the normal background after detecting movement from the mouse or keyboard. Default = 1 minute
+    [ValidateNotNullOrEmpty()]
     [timespan]$ActivityDelay = (New-Timespan -Minutes 1)
 )
 
@@ -85,7 +93,8 @@ function Get-Frames {
     (Get-ChildItem $ImagePath).FullName
 }
 
-function Set-WallPaper {
+function Set-Wallpaper {
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -110,6 +119,24 @@ public class Params
     [Params]::SystemParametersInfo($SPI_SETDESKWALLPAPER, 0, $Path, $fWinIni) | Out-Null
 }
 
+function Get-Keypress {
+    [CmdletBinding()]
+    param()
+    if (!(([System.Management.Automation.PSTypeName]"Keyboard.KeypressWatcher").Type)) {
+        Add-Type -MemberDefinition @"
+[DllImport("user32.dll", CharSet=CharSet.Auto, ExactSpelling=true)] 
+public static extern short GetAsyncKeyState(int virtualKeyCode); 
+"@ -IgnoreWarnings -Name KeypressWatcher -Namespace Keyboard
+    }
+    1..254 | ForEach-Object {
+        $state = [Keyboard.KeypressWatcher]::GetAsyncKeyState($_)
+        if ($state -eq -32767) {
+            return $_
+        }
+    }
+    0
+}
+
 try {
     $original_wallpaper = (Get-ItemProperty -Path 'HKCU:\Control Panel\Desktop' -Name Wallpaper).Wallpaper
     Write-Verbose "Original wallpaper: $original_wallpaper"
@@ -125,7 +152,7 @@ try {
 
         if ((Get-Date) -gt $checkpoint.AddSeconds($FakeoutDelay.TotalSeconds)) {
             Write-Verbose "Hit $FakeoutDelay, restoring to original and sleeping for $FakeoutDuration."
-            Set-WallPaper $original_wallpaper
+            Set-Wallpaper $original_wallpaper
             Start-Sleep $FakeoutDuration.TotalSeconds
             $checkpoint = Get-Date
         }
@@ -135,14 +162,24 @@ try {
             $new_position = [System.Windows.Forms.Cursor]::Position
             Write-Verbose "Current Mouse Pos ($new_position) | Last Mouse Pos ($last_position)"
             if ($null -ne $last_position -and $new_position -ne $last_position) {
-                Write-Host "Detected mouse movement, restoring to original and sleeping for $ActivityDelay."
-                Set-WallPaper $original_wallpaper
+                Write-Verbose "Detected mouse movement, restoring to original and sleeping for $ActivityDelay."
+                Set-Wallpaper $original_wallpaper
                 Start-Sleep $ActivityDelay.TotalSeconds
             }
             $last_position = [System.Windows.Forms.Cursor]::Position
         }
-        
-        Set-WallPaper $images[$index]
+
+        if ($WatchKeyboard) {
+            $new_keypress = Get-Keypress
+            Write-Verbose "Current Keypress ($new_keypress) | Last Keypress ($last_keypress)"
+            if ($null -ne $last_keypress -and $new_keypress -ne 0 -and $new_keypress -ne $last_keypress) {
+                Write-Verbose "Detected keypress, restoring to original and sleeping for $ActivityDelay."
+                Set-Wallpaper $original_wallpaper
+                Start-Sleep $ActivityDelay.TotalSeconds
+            }
+            $last_keypress = Get-Keypress
+        }
+        Set-Wallpaper $images[$index]
         $index = ($index + 1) % $images.Length
         Start-Sleep $FrameDelay.TotalSeconds
     }
@@ -150,8 +187,8 @@ try {
 catch {
     Write-Verbose "Hit error, terminating:"
     Write-Verbose $Error[0].ToString()
-}
+}asd
 finally {
     Remove-Item "$ImagePath\*" -ErrorAction SilentlyContinue
-    Set-WallPaper $original_wallpaper
+    Set-Wallpaper $original_wallpaper
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Michael Van Leeuwen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Invoke-Rick
 Rickroll someone's Windows desktop, restoring their original background occasionally to drive them mad.
 
+Optionally restore the original background on mouse and/or keyboard activity.
 
 **Disclaimer:** I'm not responsible if this annoys blue or any other end user. I do not have ownership over any referenced imgur images or URLs, use at your own risk!
 
@@ -12,9 +13,9 @@ iex ((New-Object System.Net.WebClient).DownloadString("https://raw.githubusercon
 ## Usage
 ```
 SYNTAX
-    C:\Users\micha\Documents\Development\Invoke-Rick\Invoke-Rick.ps1 [[-URL] <String>] [[-ImagePath] <String>] [[-FrameDelay] <TimeSpan>] [[-FakeoutDelay] <TimeSpan>] [[-FakeoutDuration] <TimeSpan>] [[-EndTime]        
-    <DateTime>] [<CommonParameters>]
-
+    C:\Users\micha\Documents\Development\Invoke-Rick\Invoke-Rick.ps1 [[-URL] <String>] [[-ImagePath] <String>]
+    [[-FrameDelay] <TimeSpan>] [[-FakeoutDelay] <TimeSpan>] [[-FakeoutDuration] <TimeSpan>] [[-EndTime] <DateTime>]
+    [-WatchMouse] [-WatchKeyboard] [[-ActivityDelay] <TimeSpan>] [<CommonParameters>]
 
 PARAMETERS
     -URL <String>
@@ -27,33 +28,49 @@ PARAMETERS
         Delay between each frame. Default = 1 second.
 
     -FakeoutDelay <TimeSpan>
-        How long to rickroll until returning to the user's normal background. Default = 1 minute.
+        How long to rickroll until returning to the normal background. Default = 1 minute.
 
     -FakeoutDuration <TimeSpan>
-        How long to remain on the user's normal background during a fakeout. Default = 5 minutes.
+        How long to remain on the normal background during a fakeout. Default = 5 minutes.
 
     -EndTime <DateTime>
         Absolute time to kill Invoke-Rick at. Default = run forever.
+
+    -WatchMouse [<SwitchParameter>]
+        Restore normal background if mouse movement is detected. Polling rate is linked with -FrameDelay.
+
+    -WatchKeyboard [<SwitchParameter>]
+        Restore normal background if keypresses is detected. Polling rate is linked with -FrameDelay.
+
+    -ActivityDelay <TimeSpan>
+        How long to remain on the normal background after detecting movement from the mouse or keyboard. Default = 1
+        minute
 
     -Verbose
         Show debug information.
 
     -------------------------- EXAMPLE 1 --------------------------
 
-    PS>iex ((New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/MJVL/Invoke-Rick/blob/main/Invoke-Rick.ps1"))
+    PS>iex ((New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/MJVL/Invoke-Rick/blob/m
+    ain/Invoke-Rick.ps1"))
         Download and run this script remotely.
 
     -------------------------- EXAMPLE 2 --------------------------
 
-    PS>.\Invoke-Rick.ps1 -FakeoutDuration (New-TimeSpan -Minutes 2) -EndTime ((Get-Date).AddMinutes(5))
-        Rickroll for 5 minutes, showing the user's original desktop every 2 minutes.
+    PS>.\Invoke-Rick.ps1 -WatchMouse -WatchKeyboard
+        Rickroll, restoring the original background temporarily if keyboard or mouse activity is detected.
 
     -------------------------- EXAMPLE 3 --------------------------
+
+    PS>.\Invoke-Rick.ps1 -FakeoutDuration (New-TimeSpan -Minutes 2) -EndTime ((Get-Date).AddMinutes(5))
+        Rickroll for 5 minutes, showing the user's original background every 2 minutes.
+
+    -------------------------- EXAMPLE 4 --------------------------
 
     PS>.\Invoke-Rick.ps1 -Verbose
         Show debug information.
 
-    -------------------------- EXAMPLE 4 --------------------------
+    -------------------------- EXAMPLE 5 --------------------------
 
     PS>Get-Help .\Invoke-Rick.ps1 -Detailed
         Get detailed help.

--- a/README.md
+++ b/README.md
@@ -3,17 +3,25 @@ Rickroll someone's Windows desktop, restoring their original background occasion
 
 Optionally restore the original background on mouse and/or keyboard activity.
 
+For more fun, set this on auto-run through use of the registry, services, injecting into PowerShell modules, or more.
+
 **Disclaimer:** I'm not responsible if this annoys blue or any other end user. I do not have ownership over any referenced imgur images or URLs, use at your own risk!
 
 ## One-liner
+PowerShell
 ```PowerShell
-iex ((New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/MJVL/Invoke-Rick/blob/main/Invoke-Rick.ps1"))
+Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/MJVL/Invoke-Rick/blob/main/Invoke-Rick.ps1"))
 ```
+Cmd
+```
+powershell.exe -ExecutionPolicy Bypass -NonInteractive -c "iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/MJVL/Invoke-Rick/blob/main/Invoke-Rick.ps1'))"
+```
+
 
 ## Usage
 ```
 SYNTAX
-    C:\Users\micha\Documents\Development\Invoke-Rick\Invoke-Rick.ps1 [[-URL] <String>] [[-ImagePath] <String>]
+    .\Invoke-Rick.ps1 [[-URL] <String>] [[-ImagePath] <String>]
     [[-FrameDelay] <TimeSpan>] [[-FakeoutDelay] <TimeSpan>] [[-FakeoutDuration] <TimeSpan>] [[-EndTime] <DateTime>]
     [-WatchMouse] [-WatchKeyboard] [[-ActivityDelay] <TimeSpan>] [<CommonParameters>]
 
@@ -51,14 +59,13 @@ PARAMETERS
 
     -------------------------- EXAMPLE 1 --------------------------
 
-    PS>iex ((New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/MJVL/Invoke-Rick/blob/m
-    ain/Invoke-Rick.ps1"))
+    PS>iex powershell.exe -ExecutionPolicy Bypass -NonInteractive -c "iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/MJVL/Invoke-Rick/blob/main/Invoke-Rick.ps1'))"
         Download and run this script remotely.
 
     -------------------------- EXAMPLE 2 --------------------------
 
-    PS>.\Invoke-Rick.ps1 -WatchMouse -WatchKeyboard
-        Rickroll, restoring the original background temporarily if keyboard or mouse activity is detected.
+    PS>.\Invoke-Rick.ps1 -WatchMouse -WatchKeyboard -ActivityDelay (New-TimeSpan -Seconds 30)
+        Rickroll, restoring the original background for 30 seconds if keyboard or mouse activity is detected.
 
     -------------------------- EXAMPLE 3 --------------------------
 


### PR DESCRIPTION
This PR adds three new params:
* `-WatchMouse`
    * Restore normal background for `-ActivityDelay` duration if mouse movement is detected
    * Polling rate based on `-FrameDelay`, fairy accurate
* `-WatchKeyboard`
    * Restore normal background for `-ActivityDelay` duration if mouse movement is detected
    * Polling rate based on `-FrameDelay`, somewhat spotty detection
 * `-ActivityDelay`
     * How long to remain on the normal background after detecting movement from the mouse or keyboard
     * Default = 1m
    
Misc fixes:
* Use permanent imgur zip url
* Increase fakeout delay from 1m -> 5m
* Add MIT license